### PR TITLE
Ensure mgo connection is always included in the context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+
+- Ensure the database connection is always stored in the context, not just
+  when CORS is enabled.
+
 ## [0.4.0] - 2017-04-04
 
 ### Added

--- a/carshare-back.go
+++ b/carshare-back.go
@@ -71,15 +71,19 @@ func main() {
 
 	if *acao != "" {
 		log.Infof("enabling CORS access for %s", *acao)
-		api.UseMiddleware(
-			func(c api2go.APIContexter, w http.ResponseWriter, r *http.Request) {
-				c.Set("db", db)
+	}
+
+	api.UseMiddleware(
+		func(c api2go.APIContexter, w http.ResponseWriter, r *http.Request) {
+			// ensure the db connection is always available in the context
+			c.Set("db", db)
+			if *acao != "" {
 				w.Header().Set("Access-Control-Allow-Origin", *acao)
 				w.Header().Set("Access-Control-Allow-Headers", "Authorization,content-type")
 				w.Header().Set("Access-Control-Allow-Methods", "GET,PATCH,DELETE,OPTIONS")
-			},
-		)
-	}
+			}
+		},
+	)
 
 	api.AddResource(
 		model.User{},


### PR DESCRIPTION
Fixed bug where the mongodb connection would only be stored in the
context if CORS is enabled.